### PR TITLE
Filter out Provides/Requires for libcycles_kernel_oneapi_aot library.

### DIFF
--- a/blender.spec
+++ b/blender.spec
@@ -9,13 +9,13 @@
 
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
-%global __requires_exclude ^(libsycl\\.so.*|libncursesw\\.so.*|libpanelw\\.so.*|libtinfo\\.so.*)$
-%global __provides_exclude ^(libsycl\\.so.*|libncursesw\\.so.*|libpanelw\\.so.*|libtinfo\\.so.*)$
+%global __requires_exclude ^(libsycl\\.so.*|libncursesw\\.so.*|libpanelw\\.so.*|libtinfo\\.so.*|libcycles_kernel_oneapi_aot\\.so.*)$
+%global __provides_exclude ^(libsycl\\.so.*|libncursesw\\.so.*|libpanelw\\.so.*|libtinfo\\.so.*|libcycles_kernel_oneapi_aot\\.so.*)$
 
 Name:       blender
 Epoch:      2
 Version:    %{blender_api}.1
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    3D modeling, animation, rendering and post-production
 License:    GPLv2
 URL:        http://www.blender.org
@@ -155,6 +155,9 @@ appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%{org}.appdata
 %{macrosdir}/macros.%{name}
 
 %changelog
+* Tue Jan 10 2023 Lars R. Damerow <lars@pixar.com> - 2:3.4.1-2
+- Filter out automatic Provides/Requires for libcycles_kernel_oneapi_aot library.
+
 * Wed Dec 21 2022 Simone Caronni <negativo17@gmail.com> - 2:3.4.1-1
 - Update to 3.4.1.
 


### PR DESCRIPTION
Hi Simone,

The blender 3.4.1 RPM has a `Requires` for `libcycles_kernel_oneapi_aot.so()(64bit)`, which is internal to the package and not included in the package's `Provides` entries. This patch filters the library out of the automatic `Requires` and `Provides` processing.

Thanks,
Lars